### PR TITLE
Use netlify `_rewrite` proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Run `npm install` then `npm start` to launch the development version, powered by
 
 ## Deploy
 
-To avoid CORS issues, the ADE API has to be proxied by the app. Nginx config for reference:
+To avoid CORS issues, the ADE API has to be proxied by the app. 
+The provided `netlify.toml` config includes this functionnality.  
+
+If you need it, here is the nginx config for reference:
 ```nginx
     location /api/v1/ {
         rewrite ^/api/v1/(.*)$ /jsp/custom/ufc/$1 break;

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/api/v1/*"
+  to = "https://sedna.univ-fcomte.fr/jsp/custom/ufc/:splat"
+  status = 200
+  force = true # COMMENT: ensure that we always redirect

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
+
 [[redirects]]
   from = "/api/v1/*"
   to = "https://sedna.univ-fcomte.fr/jsp/custom/ufc/:splat"

--- a/src/utils/ufc-edt.js
+++ b/src/utils/ufc-edt.js
@@ -8,7 +8,7 @@ export function makeGetEdt(groupId, days = 14) {
 
 		const rawData = (
 			await axios.get(
-				`https://ade-ufc-onsevoitquand.nathanaelhoun.fr/api/v1/wmplanif.jsp?id=${groupId}&jours=${days}&mode=${mode}&color=${color}&sports=${sports}`
+				`/api/v1/wmplanif.jsp?id=${groupId}&jours=${days}&mode=${mode}&color=${color}&sports=${sports}`
 			)
 		).data;
 
@@ -52,7 +52,7 @@ export function makeGetEdt(groupId, days = 14) {
 
 export function makeGetSubgroups(groupId) {
 	return async () => {
-		const rawData = (await axios.get(`https://ade-ufc-onsevoitquand.nathanaelhoun.fr/api/v1/wmselect.jsp?id=${groupId}`)).data;
+		const rawData = (await axios.get(`/api/v1/wmselect.jsp?id=${groupId}`)).data;
 
 		return rawData
 			.split("\n")
@@ -68,7 +68,7 @@ export function makeGetSubgroups(groupId) {
 
 export function makeGetHierarchyToSubgroup(subGroupId) {
 	async function recursiveRequest(current, previous) {
-		const rawData = (await axios.get(`https://ade-ufc-onsevoitquand.nathanaelhoun.fr/api/v1/wmselect.jsp?id=${current}`)).data.trim();
+		const rawData = (await axios.get(`/api/v1/wmselect.jsp?id=${current}`)).data.trim();
 		const parentMatches = /^1;([0-9]+);\.\.$/m.exec(rawData);
 
 		const groupName = new RegExp(`^1;${previous};(.+?)(?:;.*)?$`, "m").exec(rawData)?.[1] ?? "";


### PR DESCRIPTION
- Use the proxy provided by netflify to avoid CORS issues when calling the API. This will remove the need to use another proxy in front of the app.